### PR TITLE
py3 port: Fix GObject.connect argument type

### DIFF
--- a/scc/gui/statusicon.py
+++ b/scc/gui/statusicon.py
@@ -312,8 +312,8 @@ class StatusIconProxy(StatusIcon):
 		try:
 			# Try loading GTK native status icon
 			self._status_gtk = StatusIconGTK3(*args, **kwargs)
-			self._status_gtk.connect(b"clicked",        self._on_click)
-			self._status_gtk.connect(b"notify::active", self._on_notify_active_gtk)
+			self._status_gtk.connect("clicked",        self._on_click)
+			self._status_gtk.connect("notify::active", self._on_notify_active_gtk)
 			self._on_notify_active_gtk()
 			
 			log.info("Using backend StatusIconGTK3 (primary)")


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.8/site-packages/scc/gui/app.py", line 1322, in do_startup
    self.setup_statusicon()
  File "/usr/lib64/python3.8/site-packages/scc/gui/app.py", line 237, in setup_statusicon
    self.statusicon = get_status_icon(self.imagepath, menu)
  File "/usr/lib64/python3.8/site-packages/scc/gui/statusicon.py", line 421, in get_status_icon
    return StatusIconProxy(*args, **kwargs)
  File "/usr/lib64/python3.8/site-packages/scc/gui/statusicon.py", line 315, in __init__
    self._status_gtk.connect(b"clicked",        self._on_click)
TypeError: GObject.connect() argument 1 must be str, not bytes
```