### PR TITLE
Fix printf format specifiers for size_t arguments

### DIFF
--- a/scc/cemuhook_server.c
+++ b/scc/cemuhook_server.c
@@ -180,7 +180,7 @@ static void parse_message(int fd, const char* buffer, size_t size, struct sockad
 		return;
 	}
 	if (size < msg->packet_size + 20 - 4) {
-		WARN("Recieved invalid message: Invalid size (expected %i, got %i)", msg->packet_size + 20 - 4, size);
+		WARN("Recieved invalid message: Invalid size (expected %i, got %zu)", msg->packet_size + 20 - 4, size);
 		return;
 	}
 	

--- a/scc/drivers/remotepad_controller.c
+++ b/scc/drivers/remotepad_controller.c
@@ -40,7 +40,7 @@ void remotepad_input(RemotePad* pad, struct remote_joypad_message* msg) {
 	// LOG("on_data_ready %i %i %i %i", msg->device, msg->index, msg->id, msg->state);
 	
 	if (sizeof(SCButton) != sizeof(uint32_t)) {
-		printf("sizeof(SCButton) != sizeof(uint32_t): %i != %i\n",
+		printf("sizeof(SCButton) != sizeof(uint32_t): %zu != %zu\n",
 				sizeof(SCButton), sizeof(uint32_t));
 	}
 	


### PR DESCRIPTION
This fixes a couple of compiler warnings on amd64 when building the C portion of the code:

    x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -ggdb -fPIC -I/usr/include/python3.7m -c scc/drivers/hiddrv.c -o /var/tmp/portage/sys-apps/sc-controller-9999/work/sc-controller-9999-python3_7/temp.linux-x86_64-3.7/scc/drivers/hiddrv.o
    scc/drivers/remotepad_controller.c: In function ‘remotepad_input’:
    scc/drivers/remotepad_controller.c:43:50: warning: format ‘%i’ expects argument of type ‘int’, but argument 2 has type ‘long unsigned int’ [-Wformat=]
       43 |   printf("sizeof(SCButton) != sizeof(uint32_t): %i != %i\n",
          |                                                 ~^
          |                                                  |
          |                                                  int
          |                                                 %li
       44 |     sizeof(SCButton), sizeof(uint32_t));
          |     ~~~~~~~~~~~~~~~~                              
          |     |
          |     long unsigned int
    scc/drivers/remotepad_controller.c:43:56: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]
       43 |   printf("sizeof(SCButton) != sizeof(uint32_t): %i != %i\n",
          |                                                       ~^
          |                                                        |
          |                                                        int
          |                                                       %li
       44 |     sizeof(SCButton), sizeof(uint32_t));
          |                       ~~~~~~~~~~~~~~~~                  
          |                       |
          |                       long unsigned int
    x86_64-pc-linux-gnu-gcc -shared -Wl,-O1 -Wl,--as-needed -O2 -pipe -march=native -ggdb /var/tmp/portage/sys-apps/sc-controller-9999/work/sc-controller-9999-python3_7/temp.linux-x86_64-3.7/scc/drivers/remotepad_controller.o -L/usr/lib64 -lpython3.7m -o /var/tmp/portage/sys-apps/sc-controller-9999/work/sc-controller-9999-python3_7/lib/libremotepad.cpython-37m-x86_64-linux-gnu.so
    In file included from scc/cemuhook_server.c:23:
    scc/cemuhook_server.c: In function ‘parse_message’:
    scc/c_branch.h:10:45: warning: format ‘%i’ expects argument of type ‘int’, but argument 4 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
       10 | #define WARN(fmt, ...) do { fprintf(stderr, "W " LOG_TAG " " fmt, ##__VA_ARGS__); fprintf(stderr, "\n"); fflush(stderr); } while(0)
          |                                             ^~~~
    scc/cemuhook_server.c:183:3: note: in expansion of macro ‘WARN’
      183 |   WARN("Recieved invalid message: Invalid size (expected %i, got %i)", msg->packet_size + 20 - 4, size);
          |   ^~~~
    scc/cemuhook_server.c:183:67: note: format string is defined here
      183 |   WARN("Recieved invalid message: Invalid size (expected %i, got %i)", msg->packet_size + 20 - 4, size);
          |                                                                  ~^
          |                                                                   |
          |                                                                   int
          |                                                                  %li
