### PR TITLE
Fix TypeError when clicking on the status icon

### DIFF
--- a/scc/gui/statusicon.py
+++ b/scc/gui/statusicon.py
@@ -322,7 +322,7 @@ class StatusIconProxy(StatusIcon):
 			self._load_fallback()
 	
 	def _on_click(self, *args):
-		self.emit(b"clicked")
+		self.emit("clicked")
 	
 	def _on_notify_active_gtk(self, *args):
 		if self._status_fb:


### PR DESCRIPTION
The error was:

```
TypeError: GObject.emit() argument 1 must be str, not bytes
```