### PR TITLE
fixed BT support for Python3

### DIFF
--- a/.kateconfig
+++ b/.kateconfig
@@ -1,0 +1,1 @@
+kate: tab-indents on; space-indent off;

--- a/scc/device_monitor.py
+++ b/scc/device_monitor.py
@@ -124,7 +124,8 @@ class DeviceMonitor(Monitor):
 			try:
 				node_addr = DeviceMonitor._find_bt_address(node)
 				#Joe: somehow my node_addr is in lowercase
-				node_addr = str.upper(node_addr)
+				if node_addr is not None:
+					node_addr = str.upper(node_addr)
 			except IOError:
 				continue
 			if node_addr == addr:

--- a/scc/device_monitor.py
+++ b/scc/device_monitor.py
@@ -123,6 +123,8 @@ class DeviceMonitor(Monitor):
 			node = os.path.join("/sys/bus/hid/devices/", fname)
 			try:
 				node_addr = DeviceMonitor._find_bt_address(node)
+				#Joe: somehow my node_addr is in lowercase
+				node_addr = str.upper(node_addr)
 			except IOError:
 				continue
 			if node_addr == addr:

--- a/scc/drivers/sc_by_bt.py
+++ b/scc/drivers/sc_by_bt.py
@@ -202,9 +202,9 @@ class SCByBt(SCController):
 		))
 	
 	
-	def read_serial(self):	
+	def read_serial(self):
 		self._serial = (self._hidrawdev
-			.getPhysicalAddress().replace(":", ""))
+			.getPhysicalAddress().replace(b":", b""))
 	
 	
 	def send_control(self, index, data):

--- a/scc/drivers/sc_by_bt.py
+++ b/scc/drivers/sc_by_bt.py
@@ -176,10 +176,9 @@ class SCByBt(SCController):
 		 - uint8	led
 		 - 60b		unused
 		"""
-		
 		# idle_timeout is ignored
 		if enable_gyros is not None : self._enable_gyros = enable_gyros
-		if led_level is not None: self._led_level = led_level
+		if led_level is not None: self._led_level = int(led_level)
 		
 		unknown1 = b'\x00\x00\x31\x02\x00\x08\x07\x00\x07\x07\x00\x30'
 		unknown2 = b'\x00\x2e'

--- a/scc/drivers/sc_dongle.py
+++ b/scc/drivers/sc_dongle.py
@@ -237,7 +237,7 @@ class SCController(Controller):
 		def cb(rawserial):
 			size, serial = struct.unpack(">xBx12s49x", rawserial)
 			if size > 1:
-				serial = serial.strip(b" \x00")
+				serial = serial.strip(b" \x00").decode('ASCII')
 				self._serial = serial
 				self.on_serial_got()
 			else:

--- a/scc/drivers/sc_dongle.py
+++ b/scc/drivers/sc_dongle.py
@@ -237,7 +237,7 @@ class SCController(Controller):
 		def cb(rawserial):
 			size, serial = struct.unpack(">xBx12s49x", rawserial)
 			if size > 1:
-				serial = serial.strip(" \x00")
+				serial = serial.strip(b" \x00")
 				self._serial = serial
 				self.on_serial_got()
 			else:

--- a/scc/sccdaemon.py
+++ b/scc/sccdaemon.py
@@ -831,7 +831,7 @@ class SCCDaemon(Daemon):
 				action = TalkingActionParser().restart(actionstr).parse().compress()
 			except Exception as e:
 				e = str(e).encode("utf-8").decode('unicode_escape').encode("latin1")
-				client.wfile.write(b"Fail: failed to parse: " + e + "\n")
+				client.wfile.write(b"Fail: failed to parse: " + e + b"\n")
 				return
 			with self.lock:
 				try:


### PR DESCRIPTION
Hi,

I could not live any longer with the USB cable and fixed the BT support.

It had two issues on my Arch system since I think updating kernel >= 5

BT-hardware addresses seems to be in lowercase now (sometimes)  
and scc/drivers/sc_by_bt.py was not quite ready for Python3 yet after getting that one fixed.

Would you like to take a look? Can you verify if yours works as well? Or if it worked without those changes?