### PR TITLE
Fix tests and deprecation warnings

### DIFF
--- a/scc/actions.py
+++ b/scc/actions.py
@@ -357,7 +357,7 @@ class Action(object):
 		if as_strings is set to True, all parameters are converted to apropriate
 		strings (x.name for enums, x.encode('unicode_escape') for strings,
 		"""
-		argspec = inspect.getargspec(self.__class__.__init__)
+		argspec = inspect.getfullargspec(self.__class__.__init__)
 		required_count = len(argspec.args) - len(argspec.defaults) - 1
 		d = list(argspec.defaults)
 		l = list(self.parameters)

--- a/scc/actions.py
+++ b/scc/actions.py
@@ -383,7 +383,7 @@ class Action(object):
 		if parameter in PARSER_CONSTANTS:
 			return parameter
 		if type(parameter) == str:
-			return "'%s'" % (str(parameter).encode("latin1").decode('unicode_escape'),)
+			return "'%s'" % (str(parameter),)
 		return nameof(parameter)
 	
 	
@@ -1426,7 +1426,7 @@ class TrackballAction(Action):
 	COMMAND = "trackball"
 	
 	def __new__(cls, speed=None):
-		from modifiers import BallModifier
+		from scc.modifiers import BallModifier
 		return BallModifier(MouseAction(speed=speed))
 
 

--- a/scc/modifiers.py
+++ b/scc/modifiers.py
@@ -94,7 +94,7 @@ class Modifier(Action):
 		Overrides Action.strip_defaults; Uses defaults from _mod_init instead
 		of __init__, but does NOT include last of original parameters - action.
 		"""
-		argspec = inspect.getargspec(self.__class__._mod_init)
+		argspec = inspect.getfullargspec(self.__class__._mod_init)
 		required_count = len(argspec.args) - len(argspec.defaults) - 1
 		l = list(self.parameters[0:-1])
 		d = list(argspec.defaults)[0:len(l)]

--- a/scc/special_actions.py
+++ b/scc/special_actions.py
@@ -48,8 +48,7 @@ class ChangeProfileAction(Action, SpecialAction):
 	
 	
 	def to_string(self, multiline=False, pad=0):
-		return (" " * pad) + "%s('%s')" % (self.COMMAND,
-				self.profile.encode('utf-8').decode('unicode_escape'))
+		return (" " * pad) + "%s('%s')" % (self.COMMAND, self.profile)
 	
 	
 	def button_release(self, mapper):
@@ -84,7 +83,7 @@ class ShellCommandAction(Action, SpecialAction):
 	
 	
 	def to_string(self, multiline=False, pad=0):
-		return (" " * pad) + "%s('%s')" % (self.COMMAND, self.parameters[0].encode('unicode_escape'))
+		return (" " * pad) + "%s('%s')" % (self.COMMAND, self.parameters[0])
 	
 	
 	def button_press(self, mapper):
@@ -233,7 +232,7 @@ class OSDAction(Action, SpecialAction):
 		if self.action:
 			parameters.append(self.action.to_string(multiline=multiline, pad=pad))
 		else:
-			parameters.append("'%s'" % (str(self.text).encode('unicode_escape'),))
+			parameters.append("'%s'" % (str(self.text),))
 		return (" " * pad) + "%s(%s)" % (self.COMMAND, ",".join(parameters))
 	
 	
@@ -537,7 +536,7 @@ class DialogAction(Action, SpecialAction):
 			rv += "%s, " % (nameof(self.confirm_with),)
 			if self.cancel_with != DEFAULT:
 				rv += "%s, " % (nameof(self.cancel_with),)
-		rv += "'%s', " % (self.text.encode('unicode_escape'),)
+		rv += "'%s', " % (self.text,)
 		if multiline:
 			rv += "\n%s" % (" " * (pad + 2))
 		for option in self.options:

--- a/scc/tools.py
+++ b/scc/tools.py
@@ -12,7 +12,11 @@ from scc.paths import get_profiles_path, get_default_profiles_path
 from scc.paths import get_menus_path, get_default_menus_path
 from scc.paths import get_button_images_path
 from math import pi as PI, sin, cos, atan2, sqrt
-import os, sys, ctypes, imp, shlex, gettext, logging
+import os
+import ctypes
+import shlex
+import logging
+import importlib.machinery
 
 HAVE_POSIX1E = False
 try:
@@ -323,8 +327,7 @@ def find_library(libname):
 	"""
 	base_path = os.path.dirname(__file__)
 	lib, search_paths = None, []
-	so_extensions = [ ext for ext, _, typ in imp.get_suffixes()
-			if typ == imp.C_EXTENSION ]
+	so_extensions = importlib.machinery.EXTENSION_SUFFIXES
 	for extension in so_extensions:
 		search_paths += [
 			os.path.abspath(os.path.normpath(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -15,8 +15,10 @@ class TestDocs(object):
 		Tests if every known Action is documentated in docs/actions.md
 		"""
 		# Read docs first
-		actions_md = file("docs/actions.md", "r").read()
-		profile_md = file("docs/profile-file.md", "r").read()
+		with open("docs/actions.md") as f:
+			actions_md = f.read()
+		with open("docs/profile-file.md") as f:
+			profile_md = f.read()
 		
 		# Do stupid fulltext search, because currently it's simply fast enough
 		for command in Action.ALL:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -126,7 +126,7 @@ class TestInputs(object):
 		
 		# Create movement over left pad
 		state = ZERO_STATE
-		for x in reversed(xrange(STICK_PAD_MIN * 2 / 3, -10, 1000)):
+		for x in reversed(range(STICK_PAD_MIN * 2 // 3, -10, 1000)):
 			new_state = state._replace(buttons=SCButtons.LPADTOUCH, lpad_x=x)
 			mapper.input(mapper.controller, state, new_state)
 			state = new_state
@@ -134,7 +134,7 @@ class TestInputs(object):
 		# Release left pad
 		mapper.input(mapper.controller, state, ZERO_STATE)
 		# 'Wait' for 2s
-		for x in xrange(20):
+		for x in range(20):
 			mapper.input(mapper.controller, ZERO_STATE, ZERO_STATE)
 		assert int(mapper.mouse.scroll_x) == -24479
 	
@@ -182,7 +182,7 @@ class TestInputs(object):
 		
 		# Create movement over right pad
 		state = ZERO_STATE
-		for x in xrange(10, STICK_PAD_MAX * 2 / 3, 3000):
+		for x in range(10, STICK_PAD_MAX * 2 // 3, 3000):
 			new_state = state._replace(buttons=SCButtons.RPADTOUCH, rpad_x=x)
 			mapper.input(mapper.controller, state, new_state)
 			state = new_state
@@ -191,15 +191,15 @@ class TestInputs(object):
 		mapper._tick_rate = 0.001
 		mapper.input(mapper.controller, state, ZERO_STATE)
 		# 'Wait' for 1s
-		for x in xrange(100):
+		for x in range(100):
 			mapper.input(mapper.controller, ZERO_STATE, ZERO_STATE)
 		assert mapper.gamepad.axes[Axes.ABS_RX] == 3510
 		# 'Wait' for another 0.5s
-		for x in xrange(50):
+		for x in range(50):
 			mapper.input(mapper.controller, ZERO_STATE, ZERO_STATE)
 		assert mapper.gamepad.axes[Axes.ABS_RX] == 1570
 		# 'Wait' for long time so stick recenters
-		for x in xrange(100):
+		for x in range(100):
 			mapper.input(mapper.controller, ZERO_STATE, ZERO_STATE)
 		assert mapper.gamepad.axes[Axes.ABS_RX] == 0
 	

--- a/tests/test_strings/__init__.py
+++ b/tests/test_strings/__init__.py
@@ -21,7 +21,7 @@ def _same_action(a1, a2):
 	Done by comparing .parameters list and .to_string() output.
 	"""
 	assert len(a1.parameters) == len(a2.parameters)
-	for i in xrange(0, len(a1.parameters)):
+	for i in range(0, len(a1.parameters)):
 		if isinstance(a1.parameters[i], Action):
 			assert isinstance(a2.parameters[i], Action), "Parameter missmatch"
 			assert _same_action(a1.parameters[i], a2.parameters[i])

--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -1,7 +1,8 @@
 from scc.lib.vdf import parse_vdf
 from scc.foreign.vdf import VDFProfile
-from cStringIO import StringIO
-import os, pytest
+from io import StringIO
+import os
+import pytest
 
 class TestVDF(object):
 	""" Tests VDF parser """


### PR DESCRIPTION
I'm considering using this fork in [Nixpkgs](https://github.com/NixOS/nixpkgs): keeping sc-controller working after the Python 2 deprecation will be more and more time consuming. Before that, I need at least all the tests to be passing. This PR fixes all the tests failures and a couple of deprecation warnings I found along the way.

The tests are passing and everything seems to work ok, but I'm not familiar with the project this could use some review.