### PR TITLE
Fixing an AttributeError

### DIFF
--- a/scc/sccdaemon.py
+++ b/scc/sccdaemon.py
@@ -786,8 +786,7 @@ class SCCDaemon(Daemon):
 					client.wfile.write(b"Fail: cannot display OSD\n")
 		elif message.startswith(b"Feedback:"):
 			try:
-				message = message.decode("utf-8")
-				position, amplitude = message[9:].strip().split(" ", 2)
+				position, amplitude = message[9:].strip().split(b" ", 2)
 				data = HapticData(
 					getattr(HapticPos, position.strip(" \t\r")),
 					int(amplitude)
@@ -832,8 +831,7 @@ class SCCDaemon(Daemon):
 				client.mapper.get_controller().set_led_level(number)
 		elif message.startswith(b"Observe:"):
 			if Config()["enable_sniffing"]:
-				message = message.decode("utf-8")
-				to_observe = [ x for x in message.split(":", 1)[1].strip(" \t\r").split(" ") ]
+				to_observe = [ x for x in message.split(b":", 1)[1].strip(b" \t\r").split(b" ") ]
 				with self.lock:
 					for l in to_observe:
 						client.observe_action(self, SCCDaemon.source_to_constant(l))
@@ -843,8 +841,7 @@ class SCCDaemon(Daemon):
 				client.wfile.write(b"Fail: Sniffing disabled.\n")
 		elif message.startswith(b"Replace:"):
 			try:
-				message = message.decode("utf-8")
-				l, actionstr = message.split(":", 1)[1].strip(" \t\r").split(" ", 1)
+				l, actionstr = message.split(b":", 1)[1].strip(b" \t\r").split(b" ", 1)
 				action = TalkingActionParser().restart(actionstr).parse().compress()
 			except Exception as e:
 				e = str(e).encode("utf-8").decode('unicode_escape').encode("latin1")
@@ -936,8 +933,7 @@ class SCCDaemon(Daemon):
 			client.wfile.write(b"OK.\n")
 		elif message.startswith(b"Gesture:"):
 			try:
-				message = message.decode("utf-8")
-				what, up_angle = message[8:].strip().split(" ", 2)
+				what, up_angle = message[8:].strip().split(b" ", 2)
 				up_angle = int(up_angle)
 			except Exception as  e:
 				tb = str(traceback.format_exc()).encode("utf-8").decode('unicode_escape').encode("latin1")


### PR DESCRIPTION
With the recent changes I'm getting the following errors when I try to enable the Input Test Mode, so I'm making another pull request with the same kind of modifications like in #24.
Sorry, I deleted the lines you added there with 3ab9627, but I couldn't get it to work otherwise.

```
Exception occurred during processing of request from 
Traceback (most recent call last):
  File "/usr/lib/python3.9/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.9/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.9/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib/python3.9/site-packages/scc/sccdaemon.py", line 682, in handle
    instance._sshandler(self.connection, self.rfile, self.wfile)
  File "/usr/lib/python3.9/site-packages/scc/sccdaemon.py", line 746, in _sshandler
    self._handle_message(client, line.strip(b"\n"))
  File "/usr/lib/python3.9/site-packages/scc/sccdaemon.py", line 839, in _handle_message
    client.observe_action(self, SCCDaemon.source_to_constant(l))
  File "/usr/lib/python3.9/site-packages/scc/sccdaemon.py", line 1097, in source_to_constant
    s = s.decode("utf-8").strip(" \t\r\n")
AttributeError: 'str' object has no attribute 'decode'

```