### PR TITLE
Fix wayland overlay submenu layering and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Based on [Standalone Steam Controller Driver](https://github.com/ynsta/steamcont
   - [python-pylibacl](http://pylibacl.k1024.org/) is recommended
   - [python-evdev](https://python-evdev.readthedocs.io/en/latest/) is strongly recommended
   - [python-vdf](https://pypi.org/project/vdf/)
+  - [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell) (Wayland only)
 
 ### Installing
   - Download and extract  [latest release](https://github.com/kozec/sc-controller/releases/latest)

--- a/scc/osd/menu.py
+++ b/scc/osd/menu.py
@@ -41,8 +41,8 @@ class Menu(OSDWindow):
 	PREFER_BW_ICONS = True
 	
 	
-	def __init__(self, cls="osd-menu"):
-		OSDWindow.__init__(self, cls)
+	def __init__(self, cls="osd-menu", layer = None):
+		OSDWindow.__init__(self, cls, layer)
 		self.daemon = None
 		self.config = None
 		self.feedback = None
@@ -70,7 +70,6 @@ class Menu(OSDWindow):
 		self._control_with_dpad = False
 		self._confirm_with = 'A'
 		self._cancel_with = 'B'
-	
 	
 	def set_is_submenu(self):
 		"""
@@ -468,13 +467,20 @@ class Menu(OSDWindow):
 			self._selected = self._submenu._selected
 			self.quit(self._submenu.get_exit_code())
 		self._submenu = None
+		if self.using_wlroots:
+			self.layer_shell.set_layer(self, self.layer_shell.Layer.OVERLAY)
 	
 	
 	def show_submenu(self, trash, trash2, trash3, menuitem):
 		""" Called when user chooses menu item pointing to submenu """
 		filename = find_menu(menuitem.filename)
 		if filename:
-			self._submenu = self.__class__()
+			layer = None
+			if self.using_wlroots:
+				if self.layer_shell.is_supported(): 
+					layer = self.layer_shell.Layer.OVERLAY
+					self.layer_shell.set_layer(self, self.layer_shell.Layer.TOP)
+			self._submenu = self.__class__(layer = layer)
 			sub_pos = list(self.position)
 			for i in (0, 1):
 				sub_pos[i] = (sub_pos[i] - self.SUBMENU_OFFSET


### PR DESCRIPTION
For some reason, the ordering of surfaces in a single layer is undefined in the Wayland layer shell protocol, so this leads to the overlay layering acting differently on Sway and KDE. On Sway, the last opened menu is on the bottom, meaning that it will be hidden behind an older window, which is obviously not wanted. This is a somewhat hacky fix to work around that, essentially putting the last opened submenu in the highest layer and every other submenu in the lower layer. In the mean time I opened an issue in the wlroots protocol repository to hopefully get some way of setting arbitrary orders within a single layer into the protocol.
Also a less hacky fix for the menu positioning and updating the readme to mention GTK Layer Shell for overlays/menus on wayland.