### PR TITLE
Allow Bluetooth evdev and HID controllers to appear in the list

### DIFF
--- a/scc/gui/creg/dialog.py
+++ b/scc/gui/creg/dialog.py
@@ -742,7 +742,9 @@ class ControllerRegistration(Editor):
 		for fname in evdev.list_devices():
 			dev = evdev.InputDevice(fname)
 			is_gamepad = ControllerRegistration.does_he_looks_like_a_gamepad(dev)
-			if not dev.phys:
+			# bustype 3 is BUS_USB, which is the type used for emulated
+			# gamepads. phys is blank for BUS_BLUETOOTH devices.
+			if dev.info.bustype == 3 and not dev.phys:
 				# Skipping over virtual devices so list doesn't show
 				# gamepads emulated by SCC
 				continue


### PR DESCRIPTION
My Xbox 360 USB wireless receiver broke, so I figured I'd move with the times and switch to Bluetooth. Some games need help from sc-controller, but it's not seeing my Wii U Pro or Switch Pro controllers when they are connected via Bluetooth. They work fine with most Steam and SDL-based games.

I tracked this down to the line where sc-controller checks whether `dev.phys` is blank to work out whether the device is virtual or not. Unfortunately, this is also blank for Bluetooth-connected devices.

I thought checking whether `dev.info.bustype` is `BUS_VIRTUAL` might help but our emulated gamepad has `BUS_USB`. Given that we deliberately make the emulated device look as real as possible, I can't find any other way to tell it apart from real USB devices. We should therefore only check whether `dev.phys` is blank when the bustype is `BUS_USB`. This will allow Bluetooth devices with `BUS_BLUETOOTH` to work.