### PR TITLE
Fix Evdev and HID driver crash after bd758c0

### DIFF
--- a/scc/drivers/evdevdrv.py
+++ b/scc/drivers/evdevdrv.py
@@ -34,6 +34,7 @@ FIRST_BUTTON = 288
 
 EvdevControllerInput = namedtuple('EvdevControllerInput',
 	'buttons ltrig rtrig stick_x stick_y lpad_x lpad_y rpad_x rpad_y '
+	'accel_x accel_y accel_z '
 	'gpitch groll gyaw q1 q2 q3 q4 '
 	'cpad_x cpad_y'
 )

--- a/scc/drivers/hiddrv.c
+++ b/scc/drivers/hiddrv.c
@@ -8,7 +8,7 @@
 #define HIDDRV_MODULE_VERSION 5
 PyObject* module;
 
-#define AXIS_COUNT 17
+#define AXIS_COUNT 20
 #define BUTTON_COUNT 32
 
 struct HIDControllerInput {
@@ -26,15 +26,18 @@ enum AxisType {
 	AXIS_STICK_Y = 5,
 	AXIS_LTRIG   = 6,
 	AXIS_RTRIG   = 7,
-	AXIS_GPITCH  = 8,
-	AXIS_GROLL   = 9,
-	AXIS_GYAW    = 10,
-	AXIS_Q1      = 11,
-	AXIS_Q2      = 12,
-	AXIS_Q3      = 13,
-	AXIS_Q4      = 14,
-	AXIS_CPAD_X  = 15,
-	AXIS_CPAD_Y  = 16,
+	AXIS_ACCEL_X = 8,
+	AXIS_ACCEL_Y = 9,
+	AXIS_ACCEL_Z = 10,
+	AXIS_GPITCH  = 11,
+	AXIS_GROLL   = 12,
+	AXIS_GYAW    = 13,
+	AXIS_Q1      = 14,
+	AXIS_Q2      = 15,
+	AXIS_Q3      = 16,
+	AXIS_Q4      = 17,
+	AXIS_CPAD_X  = 18,
+	AXIS_CPAD_Y  = 19,
 	_AxisType_force_int = INT_MAX
 };
 

--- a/scc/drivers/hiddrv.py
+++ b/scc/drivers/hiddrv.py
@@ -23,7 +23,7 @@ log = logging.getLogger("HID")
 DEV_CLASS_HID = 3
 TRANSFER_TYPE_INTERRUPT = 3
 LIBUSB_DT_REPORT = 0x22
-AXIS_COUNT = 17		# Must match number of axis fields in HIDControllerInput and values in AxisType
+AXIS_COUNT = 20		# Must match number of axis fields in HIDControllerInput and values in AxisType
 BUTTON_COUNT = 32	# Must match (or be less than) number of bits in HIDControllerInput.buttons
 ALLOWED_SIZES = [1, 2, 4, 8, 16, 32]
 SYS_DEVICES = "/sys/devices"
@@ -54,6 +54,9 @@ class HIDControllerInput(ctypes.Structure):
 		('stick_y', ctypes.c_int32),
 		('ltrig', ctypes.c_int32),
 		('rtrig', ctypes.c_int32),
+		('accel_x', ctypes.c_int32),
+		('accel_y', ctypes.c_int32),
+		('accel_z', ctypes.c_int32),
 		('gpitch', ctypes.c_int32),
 		('groll', ctypes.c_int32),
 		('gyaw', ctypes.c_int32),
@@ -75,15 +78,18 @@ class AxisType(IntEnum):
 	AXIS_STICK_Y = 5
 	AXIS_LTRIG   = 6
 	AXIS_RTRIG   = 7
-	AXIS_GPITCH  = 8
-	AXIS_GROLL   = 9
-	AXIS_GYAW    = 10
-	AXIS_Q1      = 11
-	AXIS_Q2      = 12
-	AXIS_Q3      = 13
-	AXIS_Q4      = 14
-	AXIS_CPAD_X  = 15
-	AXIS_CPAD_Y  = 16
+	AXIS_ACCEL_X = 8
+	AXIS_ACCEL_Y = 9
+	AXIS_ACCEL_Z = 10
+	AXIS_GPITCH  = 11
+	AXIS_GROLL   = 12
+	AXIS_GYAW    = 13
+	AXIS_Q1      = 14
+	AXIS_Q2      = 15
+	AXIS_Q3      = 16
+	AXIS_Q4      = 17
+	AXIS_CPAD_X  = 18
+	AXIS_CPAD_Y  = 19
 
 
 class AxisMode(IntEnum):


### PR DESCRIPTION
Since bd758c0 the evdev driver crashes and it's flooding the console with the error seen below, which prevents the proper mapping of the DualShock 4 controller with a bluetooth connection.
The HID driver crashes for a similar reason too, when the controller is plugged in via USB, so I've made some changes there too.
These are fixed the issue for me, everything works as expected, but I could only test it with a DualShock 4 v2 controller.

```
E Mapper        Error while processing controller event
E Mapper        Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/scc/mapper.py", line 398, in input
    self.profile.gyro.gyro(self, state.gpitch, state.gyaw, state.groll, state.q1, state.q2, state.q3, state.q4)
  File "/usr/lib/python3.10/site-packages/scc/modifiers.py", line 1082, in gyro
    return sel.gyro(mapper, pitch, yaw, roll, *q)
  File "/usr/lib/python3.10/site-packages/scc/special_actions.py", line 764, in gyro
    -mapper.state.accel_x / CemuHookAction.ACC_RES_PER_G, # AccelX
AttributeError: 'EvdevControllerInput' object has no attribute 'accel_x'
```