### PR TITLE
fix half of the controls not working on steam deck

### DIFF
--- a/scc/drivers/steamdeck.py
+++ b/scc/drivers/steamdeck.py
@@ -192,9 +192,8 @@ class Deck(USBDevice, SCController):
 			self.daemon.add_controller(self)
 			self.configure()
 			self._ready = True
-		
-		# Don't like this version
-		#self._old_state, self._input = self._input, self._old_state
+
+		self._old_state, self._input = self._input, self._old_state
 		ctypes.memmove(ctypes.addressof(self._input), data, len(data))
 		if self._input.seq % UNLIZARD_INTERVAL == 0:
 			# Keeps lizard mode from happening
@@ -222,16 +221,13 @@ class Deck(USBDevice, SCController):
 		self._input.stick_y = apply_deadzone(self._input.stick_y, STICK_DEADZONE)
 		self._input.rstick_x = apply_deadzone(self._input.rstick_x, STICK_DEADZONE)
 		self._input.rstick_y = apply_deadzone(self._input.rstick_y, STICK_DEADZONE)
-
+		
 		# Invert Gyro Roll to match Steam Controller coordinate system
 		self._input.groll = -self._input.groll
-		
+
 		m = self.get_mapper()
 		if m:
 			self.mapper.input(self, self._old_state, self._input)
-
-		# Preserve current state into previous state object
-		self._old_state = self._input
 	
 	def close(self):
 		if self._ready:


### PR DESCRIPTION
#In this PR I reverted to the old way of swapping old_state and _input variables. For some  reason the "new" way makes half the SD controls non-functional.

I kept the gyro groll inversion. I tested it with yuzu and Kirby and the forgotten land in the minigame and the gyro seems correct. 

The only difficulty I still had was that for some reason with my SD the yaw updates with a rather large lag of ~2 seconds. I don't know if this is related to my hardware or whether more people have this problem.

See this for reference
https://user-images.githubusercontent.com/220973/166127234-a5ad1faa-ac6b-419a-beed-5b478ecd5f16.jpg

![Teracube_20230712_173202_757](https://github.com/Ryochan7/sc-controller/assets/5069005/6acde0fd-6071-419d-a76f-de73e5e606e9)

Solves
#91 